### PR TITLE
Deprecate fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# scrypt-shim
+This fork is deprecated and it is recommended to switch to [scrypt-js](https://github.com/ricmoo/scrypt-js), a pure JavaScript implementation.


### PR DESCRIPTION
This fork is deprecated and it is recommended to use [scrypt-js](https://github.com/ricmoo/scrypt-js), a pure JavaScript implementation.